### PR TITLE
Task 5 - Select + Bulk Delete Endpoint

### DIFF
--- a/backend/aiconsole/api/endpoints/agents/agent.py
+++ b/backend/aiconsole/api/endpoints/agents/agent.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from aiconsole.models.BulkDeleteRequest import BulkDeleteRequest
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
 from fastapi.responses import FileResponse, JSONResponse
 
@@ -92,6 +93,25 @@ async def delete_agent(agent_id: str):
         return JSONResponse({"status": "ok"})
     except KeyError:
         raise HTTPException(status_code=404, detail="Agent not found")
+    
+
+@router.delete("/bulk/delete", status_code=status.HTTP_204_NO_CONTENT)
+async def bulk_delete_materials(delete_request: BulkDeleteRequest):
+    deleted_count = 0
+    
+    for item_id in delete_request.ids:
+        try:
+            await delete_agent(item_id)
+            deleted_count += 1
+        except KeyError:
+            continue
+    
+    if deleted_count == 0:
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Nenhum item encontrado com os IDs fornecidos"
+        )
+    return None
 
 
 @router.get("/{asset_id}/exists")

--- a/backend/aiconsole/api/endpoints/chats/chat.py
+++ b/backend/aiconsole/api/endpoints/chats/chat.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from http.client import HTTPException
+from aiconsole.models.BulkDeleteRequest import BulkDeleteRequest
 from fastapi import APIRouter, Response, status
 from send2trash import send2trash
 
@@ -37,6 +39,25 @@ async def delete_history(chat_id: str):
             status_code=status.HTTP_404_NOT_FOUND,
             content="Chat history not found",
         )
+    
+
+@router.delete("/bulk/delete", status_code=status.HTTP_204_NO_CONTENT)
+async def bulk_delete_materials(delete_request: BulkDeleteRequest):
+    deleted_count = 0
+    
+    for item_id in delete_request.ids:
+        try:
+            await delete_history(item_id)
+            deleted_count += 1
+        except KeyError:
+            continue
+    
+    if deleted_count == 0:
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Nenhum item encontrado com os IDs fornecidos"
+        )
+    return None
 
 
 @router.get("/{chat_id}/path")

--- a/backend/aiconsole/api/endpoints/materials/material.py
+++ b/backend/aiconsole/api/endpoints/materials/material.py
@@ -16,7 +16,8 @@
 
 from typing import cast
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from aiconsole.models.BulkDeleteRequest import BulkDeleteRequest
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 
 from aiconsole.api.endpoints.registry import materials
@@ -168,6 +169,26 @@ async def delete_material(material_id: str):
         return JSONResponse({"status": "ok"})
     except KeyError:
         raise HTTPException(status_code=404, detail="Material not found")
+
+
+@router.delete("/bulk/delete", status_code=status.HTTP_204_NO_CONTENT)
+async def bulk_delete_materials(delete_request: BulkDeleteRequest):
+    deleted_count = 0
+    
+    for item_id in delete_request.ids:
+        try:
+            await project.get_project_materials().delete_asset(item_id)
+            deleted_count += 1
+        except KeyError:
+            continue
+    
+    if deleted_count == 0:
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Nenhum item encontrado com os IDs fornecidos"
+        )
+    return None
+    
 
 
 @router.get("/{asset_id}/exists")

--- a/backend/aiconsole/models/BulkDeleteRequest.py
+++ b/backend/aiconsole/models/BulkDeleteRequest.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+from typing import List
+
+class BulkDeleteRequest(BaseModel):
+    ids: List[str]

--- a/frontend/src/api/api/EditablesAPI.ts
+++ b/frontend/src/api/api/EditablesAPI.ts
@@ -161,6 +161,13 @@ async function deleteEditableObject(editableObjectType: EditableObjectType, id: 
   });
 }
 
+async function bulkDeleteEditableObjects(editableObjectType: EditableObjectType, ids: string[]) {
+    return ky.delete(`${getBaseURL()}/api/${editableObjectType}s/bulk/delete`, {
+      json: {"ids": ids},
+      hooks: API_HOOKS,
+    });
+}
+
 async function getPathForEditableObject(editableObjectType: EditableObjectType, id: string) {
   return (
     (await ky
@@ -177,6 +184,7 @@ async function setAgentAvatar(agentId: string, avatar: FormData) {
 
 export const EditablesAPI = {
   deleteEditableObject,
+  bulkDeleteEditableObjects,
   fetchEditableObjects,
   fetchEditableObject,
   setAssetStatus,

--- a/frontend/src/components/editables/sidebar/AssetsSidebarTab.tsx
+++ b/frontend/src/components/editables/sidebar/AssetsSidebarTab.tsx
@@ -16,6 +16,10 @@
 
 import { Asset, AssetStatus, AssetType } from '@/types/editables/assetTypes';
 import SideBarItem from './SideBarItem';
+import { Icon } from '@/components/common/icons/Icon';
+import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useDeleteEditableObjectWithUserInteraction } from '@/utils/editables/useDeleteEditableObjectWithUserInteraction';
 
 const getTitle = (status: AssetStatus, isAgentChosen: boolean, assetType: AssetType) => {
   switch (status) {
@@ -48,8 +52,39 @@ function groupAssetsByStatus(assets: Asset[]) {
 export const AssetsSidebarTab = ({ assetType, assets }: { assetType: AssetType; assets: Asset[] }) => {
   const groupedAssets = groupAssetsByStatus(assets);
   const hasForcedAssets = Boolean(groupedAssets[0][1].length);
+  
+  const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
+  const handleDelete = useDeleteEditableObjectWithUserInteraction(assetType);
+
+  const handleBulkDelete = () => {
+    selectedAssets.forEach((id) => handleDelete(id));
+    setSelectedAssets([]);
+  };
+
+  const handleBulkSelect = (id: string, isSelected: boolean) => {
+    setSelectedAssets((prevSelected: any[]) =>
+      isSelected
+        ? [...prevSelected, id]
+        : prevSelected.filter((itemId: string) => itemId !== id)
+    );
+  };
 
   return (
+    <>
+    <div className="h-8 w-full flex justify-end">
+      { selectedAssets.length > 0 &&
+      <button
+        onClick={handleBulkDelete}
+        className="mb-2 p-2 bg-red-500 text-white rounded-md disabled:opacity-50"
+      >
+        <Icon 
+          icon={Trash2}
+          className="w-4 h-4"
+        />
+      </button>
+      }
+    </div>
+
     <div className="flex flex-col gap-[5px] pr-[20px] overflow-y-auto h-full">
       {groupedAssets.map(([status, assets]) => {
         const title = getTitle(status, hasForcedAssets, assetType);
@@ -59,12 +94,18 @@ export const AssetsSidebarTab = ({ assetType, assets }: { assetType: AssetType; 
             <div key={status}>
               <h3 className="uppercase px-[9px] py-[5px] text-gray-400 text-[12px] leading-[18px]">{title}</h3>
               {assets.map((asset) => (
-                <SideBarItem key={asset.id} editableObject={asset} editableObjectType={assetType} />
+                <SideBarItem 
+                  key={asset.id} 
+                  editableObject={asset} 
+                  editableObjectType={assetType} 
+                  onBulkSelect={handleBulkSelect}
+                />
               ))}
             </div>
           )
         );
       })}
     </div>
+    </>
   );
 };

--- a/frontend/src/components/editables/sidebar/AssetsSidebarTab.tsx
+++ b/frontend/src/components/editables/sidebar/AssetsSidebarTab.tsx
@@ -19,7 +19,7 @@ import SideBarItem from './SideBarItem';
 import { Icon } from '@/components/common/icons/Icon';
 import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { useDeleteEditableObjectWithUserInteraction } from '@/utils/editables/useDeleteEditableObjectWithUserInteraction';
+import { useBulkDeleteEditableObjectWithUserInteraction } from '@/utils/editables/useBulkDeleteEditableObjectWithUserInteraction';
 
 const getTitle = (status: AssetStatus, isAgentChosen: boolean, assetType: AssetType) => {
   switch (status) {
@@ -54,10 +54,10 @@ export const AssetsSidebarTab = ({ assetType, assets }: { assetType: AssetType; 
   const hasForcedAssets = Boolean(groupedAssets[0][1].length);
   
   const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
-  const handleDelete = useDeleteEditableObjectWithUserInteraction(assetType);
+  const handleDelete = useBulkDeleteEditableObjectWithUserInteraction(assetType);
 
   const handleBulkDelete = () => {
-    selectedAssets.forEach((id) => handleDelete(id));
+    handleDelete(selectedAssets);
     setSelectedAssets([]);
   };
 

--- a/frontend/src/components/editables/sidebar/ChatsSidebarTab.tsx
+++ b/frontend/src/components/editables/sidebar/ChatsSidebarTab.tsx
@@ -17,14 +17,20 @@
 import { useChatStore } from '@/store/editables/chat/useChatStore';
 import { useEditablesStore } from '@/store/editables/useEditablesStore';
 import useGroupByDate from '@/utils/editables/useGroupByDate';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import SideBarItem from './SideBarItem';
+import { Icon } from '@/components/common/icons/Icon';
+import { Trash2 } from "lucide-react";
+import { useDeleteEditableObjectWithUserInteraction } from '@/utils/editables/useDeleteEditableObjectWithUserInteraction';
 
 export const ChatsSidebarTab = () => {
   const chatHeadlines = useEditablesStore((state) => state.chats);
   const chat = useChatStore((state) => state.chat);
   const { today, yesterday, previous7Days, older } = useGroupByDate(chatHeadlines);
   const setIsChatLoading = useChatStore((state) => state.setIsChatLoading);
+
+  const [selectedChats, setSelectedChats] = useState<string[]>([]);
+  const handleDelete = useDeleteEditableObjectWithUserInteraction("chat");
 
   useEffect(() => {
     if (chat?.id) {
@@ -39,22 +45,53 @@ export const ChatsSidebarTab = () => {
     { title: 'Older than 7 days', headlines: older },
   ];
 
+  const handleBulkDelete = () => {
+    selectedChats.forEach((id) => handleDelete(id));
+    setSelectedChats([]);
+  };
+
+  const handleBulkSelect = (id: string, isSelected: boolean) => {
+    setSelectedChats((prevSelected: any[]) =>
+      isSelected
+        ? [...prevSelected, id]
+        : prevSelected.filter((itemId: string) => itemId !== id)
+    );
+  };
+
   return (
     <div className="h-full flex flex-col justify-between">
       <div className="flex flex-col justify-between content-between relative overflow-y-auto">
+      <div className="h-8 w-full flex justify-end">
+        { selectedChats.length > 0 &&
+        <button
+          onClick={handleBulkDelete}
+          className="mb-2 mr-4 p-2 bg-red-500 text-white rounded-md disabled:opacity-50"
+        >
+          <Icon 
+            icon={Trash2}
+            className="w-4 h-4"
+          />
+        </button>
+        }
+      </div>
         <div className="overflow-y-auto min-h-[100px] px-5">
-          {sections.map(
+        {sections.map(
             (section) =>
               section.headlines.length > 0 && (
                 <div key={section.title}>
-                  <h3 className="uppercase px-[9px] py-[5px] text-gray-400 text-[12px] leading-[18px]">
+                  <h3 className="uppercase px-[9px] py-[5px] text-gray-400 text-[12px]">
                     {section.title}
                   </h3>
                   {section.headlines.map((chat) => (
-                    <SideBarItem key={chat.id} editableObject={chat} editableObjectType="chat" />
+                    <SideBarItem
+                      key={chat.id}
+                      editableObject={chat}
+                      editableObjectType="chat"
+                      onBulkSelect={handleBulkSelect}
+                    />
                   ))}
                 </div>
-              ),
+              )
           )}
         </div>
       </div>

--- a/frontend/src/components/editables/sidebar/ChatsSidebarTab.tsx
+++ b/frontend/src/components/editables/sidebar/ChatsSidebarTab.tsx
@@ -21,7 +21,7 @@ import { useEffect, useState } from 'react';
 import SideBarItem from './SideBarItem';
 import { Icon } from '@/components/common/icons/Icon';
 import { Trash2 } from "lucide-react";
-import { useDeleteEditableObjectWithUserInteraction } from '@/utils/editables/useDeleteEditableObjectWithUserInteraction';
+import { useBulkDeleteEditableObjectWithUserInteraction } from '@/utils/editables/useBulkDeleteEditableObjectWithUserInteraction';
 
 export const ChatsSidebarTab = () => {
   const chatHeadlines = useEditablesStore((state) => state.chats);
@@ -30,7 +30,7 @@ export const ChatsSidebarTab = () => {
   const setIsChatLoading = useChatStore((state) => state.setIsChatLoading);
 
   const [selectedChats, setSelectedChats] = useState<string[]>([]);
-  const handleDelete = useDeleteEditableObjectWithUserInteraction("chat");
+  const handleDelete = useBulkDeleteEditableObjectWithUserInteraction("chat");
 
   useEffect(() => {
     if (chat?.id) {
@@ -46,7 +46,7 @@ export const ChatsSidebarTab = () => {
   ];
 
   const handleBulkDelete = () => {
-    selectedChats.forEach((id) => handleDelete(id));
+    handleDelete(selectedChats);
     setSelectedChats([]);
   };
 

--- a/frontend/src/components/editables/sidebar/SideBarItem.tsx
+++ b/frontend/src/components/editables/sidebar/SideBarItem.tsx
@@ -181,12 +181,20 @@ const SideBarItem = ({
 
   return (
     <ContextMenu options={menuItems} ref={triggerRef} onOpenChange={handleOpenContextChange}>
-      <div className="max-w-[295px] mb-[5px]">
+      <div className="max-w-[295px] mb-[5px] flex items-center gap-2">
+        <Checkbox 
+          checked={isSelected} 
+          onCheckedChange={handleSelect}
+          className="w-5 h-5 border-2 border-gray-500 rounded-md"
+        >
+          {isSelected && <Check className="w-4 h-4 text-white"/>}
+        </Checkbox>
         <div
           className={cn(
             forced && editableObjectType === 'agent' && 'text-agent',
             forced && editableObjectType === 'material' && 'text-material',
             disabled && 'opacity-50',
+            'flex-1 min-w-0'
           )}
         >
           <NavLink
@@ -203,13 +211,6 @@ const SideBarItem = ({
           >
             {({ isActive }) => (
               <>
-                <Checkbox 
-                  checked={isSelected} 
-                  onCheckedChange={handleSelect}
-                  className="w-5 h-5 border-2 border-gray-500 rounded-md"
-                >
-                  {isSelected && <Check className="w-4 h-4 text-white"/>}
-                </Checkbox>
                 <Icon
                   icon={EditableIcon}
                   className={cn(

--- a/frontend/src/components/editables/sidebar/SideBarItem.tsx
+++ b/frontend/src/components/editables/sidebar/SideBarItem.tsx
@@ -26,16 +26,19 @@ import { convertNameToId } from '@/utils/editables/convertNameToId';
 import { getEditableObjectIcon } from '@/utils/editables/getEditableObjectIcon';
 import { useAssets } from '@/utils/editables/useAssets';
 import { useEditableObjectContextMenu } from '@/utils/editables/useContextMenuForEditable';
-import { MoreVertical } from 'lucide-react';
+import { Checkbox } from '@radix-ui/react-checkbox';
+import { Check, MoreVertical } from 'lucide-react';
 import { KeyboardEvent, MouseEvent, useEffect, useRef, useState } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 
 const SideBarItem = ({
   editableObjectType,
   editableObject,
+  onBulkSelect,
 }: {
   editableObject: EditableObject;
   editableObjectType: EditableObjectType;
+  onBulkSelect: (id: string, isSelected: boolean) => void;
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -48,6 +51,7 @@ const SideBarItem = ({
   const [isEditing, setIsEditing] = useState(false);
   const [isShowingContext, setIsShowingContext] = useState(false);
   const [blockBlur, setBlockBlur] = useState(false);
+  const [isSelected, setIsSelected] = useState(false);
 
   const showToast = useToastsStore((state) => state.showToast);
 
@@ -169,6 +173,12 @@ const SideBarItem = ({
     setIsShowingContext(open);
   };
 
+  const handleSelect = () => {
+    const newState = !isSelected;
+    setIsSelected(newState);
+    onBulkSelect(editableObject.id, newState);
+  };
+
   return (
     <ContextMenu options={menuItems} ref={triggerRef} onOpenChange={handleOpenContextChange}>
       <div className="max-w-[295px] mb-[5px]">
@@ -193,6 +203,13 @@ const SideBarItem = ({
           >
             {({ isActive }) => (
               <>
+                <Checkbox 
+                  checked={isSelected} 
+                  onCheckedChange={handleSelect}
+                  className="w-5 h-5 border-2 border-gray-500 rounded-md"
+                >
+                  {isSelected && <Check className="w-4 h-4 text-white"/>}
+                </Checkbox>
                 <Icon
                   icon={EditableIcon}
                   className={cn(

--- a/frontend/src/store/editables/EditablesSlice.ts
+++ b/frontend/src/store/editables/EditablesSlice.ts
@@ -24,6 +24,7 @@ import { isAsset } from '@/utils/editables/isAsset';
 
 export type EditablesSlice = {
   deleteEditableObject: (editableObjectType: EditableObjectType, id: string) => Promise<void>;
+  bulkDeleteEditableObjects: (editableObjectType: EditableObjectType, ids: string[]) => Promise<void>;
   canOpenFinderForEditable(editable: EditableObject): boolean;
   openFinderForEditable: (editable: EditableObject) => void;
 };
@@ -38,6 +39,19 @@ export const createEditablesSlice: StateCreator<EditablesStore, [], [], Editable
         (editableObject) => editableObject.id !== id,
       ),
     }));
+  },
+  bulkDeleteEditableObjects: async (editableObjectType: EditableObjectType, ids: string[]) => {
+    await EditablesAPI.bulkDeleteEditableObjects(editableObjectType, ids);
+    const editableObjectTypePlural = (editableObjectType + 's') as EditableObjectTypePlural;
+
+    ids.forEach((id) => {
+      set((state) => ({
+        [editableObjectTypePlural]: (state[editableObjectTypePlural] || []).filter(
+          (editableObject) => editableObject.id !== id,
+        ),
+      }));
+    });
+    
   },
   canOpenFinderForEditable: (editable: EditableObject) => {
     const editableObjectType = getEditableObjectType(editable);

--- a/frontend/src/utils/editables/useBulkDeleteEditableObjectWithUserInteraction.ts
+++ b/frontend/src/utils/editables/useBulkDeleteEditableObjectWithUserInteraction.ts
@@ -1,0 +1,30 @@
+import { useEditablesStore } from '@/store/editables/useEditablesStore';
+import { Asset, EditableObjectType } from '@/types/editables/assetTypes';
+import { useSelectedEditableObject } from './useSelectedEditableObject';
+import { isAsset } from './isAsset';
+import { useAssetStore } from '@/store/editables/asset/useAssetStore';
+import { EditablesAPI } from '@/api/api/EditablesAPI';
+
+export function useBulkDeleteEditableObjectWithUserInteraction(editableObjectType: EditableObjectType) {
+  const deleteEditableObject = useEditablesStore((state) => state.bulkDeleteEditableObjects);
+  const setSelectedAsset = useAssetStore((state) => state.setSelectedAsset);
+  const setLastSavedSelectedAsset = useAssetStore((state) => state.setLastSavedSelectedAsset);
+  const [editable] = useSelectedEditableObject();
+
+  async function handleDelete(ids: string[]) {
+    await deleteEditableObject(editableObjectType, ids);
+
+    ids.forEach(async (id) => {
+      if (editable?.id === id) {
+        if (isAsset(editableObjectType) && (editable as Asset).override) {
+          //Force reload of the current asset
+          const newAsset = await EditablesAPI.fetchEditableObject<Asset>({ editableObjectType, id });
+          setSelectedAsset(newAsset);
+          setLastSavedSelectedAsset(newAsset);
+        }
+      }
+    })
+  }
+
+  return handleDelete;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1432,9 +1432,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
-  version "1.0.30001561"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz#752f21f56f96f1b1a52e97aae98c57c562d5d9da"
-  integrity sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==
+  version "1.0.30001707"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz"
+  integrity sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==
 
 ccount@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
- The first commit performs the selection + bulk delete operation only on the frontend using the existing endpoints. What is interesting to reduce the backend's responsibility, which is a common approach in several projects.

- In the second commit, bulk delete endpoints are added for chats, materials, and agents. Also, following the project's standard for handling user interactions by setting states through EditablesSlices. It's important to keep the architecture concise🤓

💪 As I said, I love all fields of technology - backend, frontend, science, agile, etc.

## **Screenshots Scenarios:**

### **[MATERIALS]**
![image](https://github.com/user-attachments/assets/96c8a202-e584-4579-8f32-963900c45c78)
--
![image](https://github.com/user-attachments/assets/74429178-b63b-48ce-ba91-5c7deda5d974)

### **[CHATS]**

![image](https://github.com/user-attachments/assets/f49d65af-35a5-47e3-94b8-ed6b5b00c1e8)
--
![image](https://github.com/user-attachments/assets/7b288418-a71c-488b-8075-ff6a19dc5676)

### **[AGENTS]**

![image](https://github.com/user-attachments/assets/72d04881-1bc5-4488-bdaa-846c48bba23b)
--
![image](https://github.com/user-attachments/assets/dd067932-ea19-41a2-847b-574214701119)



